### PR TITLE
Need to specify the Heroku APPID

### DIFF
--- a/chat-extensions/README.md
+++ b/chat-extensions/README.md
@@ -77,7 +77,9 @@ This demo bot is immediately runnable on Heroku!
 $ cd /path/to/fb-chatbots
 
 $ heroku create
-$ heroku addons:create heroku-postgresql
+
+# HEROKU_APPID is given to you from the above command. Run `heroku apps` to list them all.
+$ heroku addons:create heroku-postgresql --app {HEROKU_APPID}
 
 # URL_TO_HEROKU_APP is the URL given to you from the above command
 $ heroku config:set APP_URL='https://{URL_TO_HEROKU_APP}'


### PR DESCRIPTION
Otherwise you get this error:

```
$ heroku addons:create heroku-postgresql
 ▸    Error: No app specified
 ▸    Usage: heroku addons:create SERVICE:PLAN --app APP
 ▸    We don't know which app to run this on.
 ▸    Run this command from inside an app folder or specify which app to use with --app APP
 ▸
 ▸    https://devcenter.heroku.com/articles/using-the-cli#app-commands
```