### PR TITLE
fix knex migration

### DIFF
--- a/chat-extensions/db/migrations/20170331112237_lists.js
+++ b/chat-extensions/db/migrations/20170331112237_lists.js
@@ -34,7 +34,7 @@ exports.up = (knex) => {
   ]);
 };
 
-exports.down = (knex, Promise) => {
+exports.down = (knex) => {
   return Promise.all([
     knex.schema.dropTable('users_lists'),
     knex.schema.dropTable('lists_items'),

--- a/chat-extensions/db/migrations/20170331112237_lists.js
+++ b/chat-extensions/db/migrations/20170331112237_lists.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-exports.up = (knex, Promise) => {
+exports.up = (knex) => {
   return Promise.all([
     knex.schema.createTable('lists', (table) => {
       table.increments();


### PR DESCRIPTION
The knex/src/migrate/Migrator.js doesn't pass a promise in, so the migration fails with:

migration file "20170331112237_lists.js" failed
migration failed with error: Cannot read property 'all' of undefined